### PR TITLE
Add parser support for user-defined types

### DIFF
--- a/crates/parser/src/ast/nodes.rs
+++ b/crates/parser/src/ast/nodes.rs
@@ -18,6 +18,7 @@ pub struct Module {
 #[derive(Debug)]
 pub enum Item {
     Fn(Func),
+    Newtype(NewtypeDef),
     Type(TypeDef),
     Literal(LiteralDef),
     Alias(AliasDef),
@@ -379,11 +380,46 @@ pub struct TypeNode {
     pub repr: String,
 }
 
+/// Named generic parameter with the original span.
+#[derive(Debug, Clone)]
+pub struct GenericParam {
+    pub name: String,
+    pub span: Span,
+}
+
+/// Field inside a struct-like type definition.
+#[derive(Debug)]
+pub struct StructField {
+    pub attrs: Vec<Attr>,
+    pub name: String,
+    pub ty: TypeNode,
+    pub default: Option<Expr>,
+    pub span: Span,
+}
+
 /// Type alias declaration.
 #[derive(Debug)]
 pub struct AliasDef {
     pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub variants: Vec<AliasVariant>,
+    pub attrs: Vec<Attr>,
     pub span: Span,
+}
+
+/// Alternatives that may appear in a type alias union.
+#[derive(Debug)]
+pub enum AliasVariant {
+    /// Plain type alternative like `int` or `Foo<T>`.
+    Type(TypeNode),
+    /// Explicit inclusion of the `nothing` sentinel type.
+    Nothing { span: Span },
+    /// Reference to a tagged constructor such as `Some(T)`.
+    Tag {
+        name: String,
+        args: Vec<TypeNode>,
+        span: Span,
+    },
 }
 
 /// Literal definition declaration stub.
@@ -393,10 +429,24 @@ pub struct LiteralDef {
     pub span: Span,
 }
 
-/// Type definition declaration stub.
+/// Struct-like type definition with optional base type extension.
 #[derive(Debug)]
 pub struct TypeDef {
     pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub base: Option<TypeNode>,
+    pub fields: Vec<StructField>,
+    pub attrs: Vec<Attr>,
+    pub span: Span,
+}
+
+/// Newtype declaration that wraps an existing type.
+#[derive(Debug)]
+pub struct NewtypeDef {
+    pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub ty: TypeNode,
+    pub attrs: Vec<Attr>,
     pub span: Span,
 }
 

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -13,9 +13,9 @@ mod sync;
 mod types;
 
 pub use ast::{
-    AliasDef, AssignOp, Ast, Attr, BinaryOp, Block, CompareArm, Expr, ExternBlock, Func, FuncSig,
-    Import, Item, LiteralDef, Module, Param, Pattern, PatternKind, Stmt, StmtOrBlock, TypeDef,
-    TypeNode, UnaryOp,
+    AliasDef, AliasVariant, AssignOp, Ast, Attr, BinaryOp, Block, CompareArm, Expr, ExternBlock,
+    Func, FuncSig, GenericParam, Import, Item, LiteralDef, Module, NewtypeDef, Param, Pattern,
+    PatternKind, Stmt, StmtOrBlock, StructField, TypeDef, TypeNode, UnaryOp,
 };
 pub use error::{ParseCode, ParseDiag};
 pub use parser::{ParseResult, parse_source, parse_source_with_options, parse_tokens};

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -4,6 +4,7 @@ use crate::ast::SpanExt;
 use crate::ast::*;
 use crate::attributes::parse_attrs;
 use crate::error::{ParseCode, ParseDiag};
+use crate::expressions::{expr_span, parse_expr};
 use crate::lexer_api::Stream;
 use crate::statements::{parse_block, parse_stmt};
 use crate::sync::is_top_level_sync;
@@ -114,9 +115,21 @@ impl<'src> Parser<'src> {
             return self.parse_extern(attrs).map(Item::Extern);
         }
 
+        if self.stream.at_keyword(Keyword::Newtype) {
+            return self.parse_newtype(attrs).map(Item::Newtype);
+        }
+
+        if self.stream.at_keyword(Keyword::Type) {
+            return self.parse_type_def(attrs).map(Item::Type);
+        }
+
+        if self.stream.at_keyword(Keyword::Alias) {
+            return self.parse_alias(attrs).map(Item::Alias);
+        }
+
         if let Some(keyword) = self.stream.peek_keyword() {
             match keyword {
-                Keyword::Type | Keyword::Literal | Keyword::Alias | Keyword::Import => {
+                Keyword::Literal | Keyword::Import => {
                     let tok = self.stream.bump();
                     self.error(
                         ParseCode::UnexpectedToken,
@@ -295,6 +308,516 @@ impl<'src> Parser<'src> {
             methods,
             span,
         })
+    }
+
+    // ========================================
+    // USER-DEFINED TYPE PARSING
+    // ========================================
+
+    /// Parse a `newtype Name = ExistingType;` declaration.
+    fn parse_newtype(&mut self, attrs: Vec<Attr>) -> Option<NewtypeDef> {
+        let Some(newtype_tok) = self.stream.eat_keyword(Keyword::Newtype) else {
+            let tok = self.stream.bump();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected 'newtype' keyword",
+            );
+            return None;
+        };
+
+        let (name, name_span) = self.expect_ident("newtype name")?;
+        let generics = self.parse_generic_params();
+
+        let Some(eq_tok) = self.stream.eat(TokenKind::Eq) else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected '=' after newtype name",
+            );
+            return None;
+        };
+
+        let ty = match parse_type_node(&mut self.stream, &mut self.diags) {
+            Some(ty) => ty,
+            None => {
+                self.error(
+                    ParseCode::UnexpectedToken,
+                    eq_tok.span,
+                    "Expected type on the right-hand side of newtype",
+                );
+                return None;
+            }
+        };
+
+        let mut span = newtype_tok.span.join(name_span);
+        if let Some(last_generic) = generics.last() {
+            span = span.join(last_generic.span);
+        }
+        span = span.join(ty.span);
+        if let Some(semi) = self.stream.eat(TokenKind::Semicolon) {
+            span = span.join(semi.span);
+        } else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::MissingSemicolon,
+                tok.span,
+                "Expected ';' after newtype definition",
+            );
+        }
+
+        Some(NewtypeDef {
+            name,
+            generics,
+            ty,
+            attrs,
+            span,
+        })
+    }
+
+    /// Parse a `type Name = Base : { ... }` or `type Name = { ... }` declaration.
+    fn parse_type_def(&mut self, attrs: Vec<Attr>) -> Option<TypeDef> {
+        let Some(type_tok) = self.stream.eat_keyword(Keyword::Type) else {
+            let tok = self.stream.bump();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected 'type' keyword",
+            );
+            return None;
+        };
+
+        let (name, name_span) = self.expect_ident("type name")?;
+        let generics = self.parse_generic_params();
+
+        let Some(eq_tok) = self.stream.eat(TokenKind::Eq) else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected '=' after type name",
+            );
+            return None;
+        };
+
+        let mut base = None;
+        let (fields, body_span) = if self.stream.at(TokenKind::LBrace) {
+            match self.parse_struct_body() {
+                Some(res) => res,
+                None => (Vec::new(), eq_tok.span),
+            }
+        } else {
+            let parsed_base = match parse_type_node(&mut self.stream, &mut self.diags) {
+                Some(ty) => {
+                    let span = ty.span;
+                    base = Some(ty);
+                    span
+                }
+                None => {
+                    self.error(
+                        ParseCode::UnexpectedToken,
+                        eq_tok.span,
+                        "Expected base type or '{' after '='",
+                    );
+                    return None;
+                }
+            };
+
+            if self.stream.eat(TokenKind::Colon).is_none() {
+                self.error(
+                    ParseCode::UnexpectedToken,
+                    self.stream.peek().span,
+                    "Expected ':' before struct extension body",
+                );
+                return None;
+            }
+
+            match self.parse_struct_body() {
+                Some((fields, span)) => (fields, parsed_base.join(span)),
+                None => (Vec::new(), parsed_base),
+            }
+        };
+
+        let mut span = type_tok.span.join(name_span);
+        if let Some(last_generic) = generics.last() {
+            span = span.join(last_generic.span);
+        }
+        if let Some(base_ty) = &base {
+            span = span.join(base_ty.span);
+        }
+        span = span.join(body_span);
+
+        if let Some(semi) = self.stream.eat(TokenKind::Semicolon) {
+            span = span.join(semi.span);
+        }
+
+        Some(TypeDef {
+            name,
+            generics,
+            base,
+            fields,
+            attrs,
+            span,
+        })
+    }
+
+    /// Parse an `alias Name = Variant | Variant;` declaration.
+    fn parse_alias(&mut self, attrs: Vec<Attr>) -> Option<AliasDef> {
+        let Some(alias_tok) = self.stream.eat_keyword(Keyword::Alias) else {
+            let tok = self.stream.bump();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected 'alias' keyword",
+            );
+            return None;
+        };
+
+        let (name, name_span) = self.expect_ident("alias name")?;
+        let generics = self.parse_generic_params();
+
+        let Some(eq_tok) = self.stream.eat(TokenKind::Eq) else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected '=' after alias name",
+            );
+            return None;
+        };
+
+        let mut variants = Vec::new();
+        let mut last_span = eq_tok.span;
+
+        while !self.stream.at(TokenKind::Semicolon) && !self.stream.is_eof() {
+            if let Some(variant) = self.parse_alias_variant() {
+                last_span = match &variant {
+                    AliasVariant::Type(ty) => ty.span,
+                    AliasVariant::Nothing { span } => *span,
+                    AliasVariant::Tag { span, .. } => *span,
+                };
+                variants.push(variant);
+            } else {
+                self.recover_in_alias_variants();
+            }
+
+            if self.stream.eat(TokenKind::Pipe).is_some() {
+                continue;
+            }
+            break;
+        }
+
+        if variants.is_empty() {
+            self.error(
+                ParseCode::UnexpectedToken,
+                self.stream.peek().span,
+                "Expected at least one alternative in alias definition",
+            );
+        }
+
+        let mut span = alias_tok.span.join(name_span);
+        if let Some(last_generic) = generics.last() {
+            span = span.join(last_generic.span);
+        }
+        span = span.join(last_span);
+        if let Some(semi) = self.stream.eat(TokenKind::Semicolon) {
+            span = span.join(semi.span);
+        } else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::MissingSemicolon,
+                tok.span,
+                "Expected ';' after alias definition",
+            );
+        }
+
+        Some(AliasDef {
+            name,
+            generics,
+            variants,
+            attrs,
+            span,
+        })
+    }
+
+    /// Parse `<T, U>` generic parameter lists shared between newtype, alias and type definitions.
+    fn parse_generic_params(&mut self) -> Vec<GenericParam> {
+        if !self.stream.at(TokenKind::LAngle) {
+            return Vec::new();
+        }
+
+        let open = self.stream.bump();
+        let mut params = Vec::new();
+
+        while !self.stream.is_eof() {
+            if self.stream.at(TokenKind::RAngle) {
+                let close = self.stream.bump();
+                if params.is_empty() {
+                    self.error(
+                        ParseCode::UnexpectedToken,
+                        close.span,
+                        "Generic parameter list cannot be empty",
+                    );
+                }
+                break;
+            }
+
+            let (name, span) = match self.expect_ident("generic parameter") {
+                Some(res) => res,
+                None => {
+                    self.recover_in_generics();
+                    break;
+                }
+            };
+            params.push(GenericParam { name, span });
+
+            if self.stream.eat(TokenKind::Comma).is_some() {
+                continue;
+            }
+
+            if self.stream.eat(TokenKind::RAngle).is_some() {
+                break;
+            }
+
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected ',' or '>' in generic parameter list",
+            );
+            self.recover_in_generics();
+            break;
+        }
+
+        if !params.is_empty() {
+            params
+        } else {
+            self.error(
+                ParseCode::UnexpectedToken,
+                open.span,
+                "Expected at least one generic parameter",
+            );
+            Vec::new()
+        }
+    }
+
+    /// Parse `{ field: Type, ... }` bodies used by struct definitions.
+    fn parse_struct_body(&mut self) -> Option<(Vec<StructField>, Span)> {
+        let Some(open) = self.stream.eat(TokenKind::LBrace) else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected '{' to start type body",
+            );
+            return None;
+        };
+
+        let mut fields = Vec::new();
+        let mut last_span = open.span;
+
+        while !self.stream.at(TokenKind::RBrace) && !self.stream.is_eof() {
+            let attrs = parse_attrs(&mut self.stream, &mut self.diags);
+
+            if self.stream.at(TokenKind::RBrace) {
+                if !attrs.is_empty() {
+                    self.error(
+                        ParseCode::UnexpectedToken,
+                        self.stream.peek().span,
+                        "Expected field declaration after attributes",
+                    );
+                }
+                break;
+            }
+
+            let (name, name_span) = match self.expect_ident("field name") {
+                Some(res) => res,
+                None => {
+                    self.recover_in_struct_fields();
+                    self.stream.eat(TokenKind::Comma);
+                    continue;
+                }
+            };
+
+            let mut span = name_span;
+
+            if self.stream.eat(TokenKind::Colon).is_none() {
+                self.error(
+                    ParseCode::MissingColonInType,
+                    name_span,
+                    "Expected ':' before field type",
+                );
+                self.recover_in_struct_fields();
+                self.stream.eat(TokenKind::Comma);
+                continue;
+            }
+
+            let ty = match parse_type_node(&mut self.stream, &mut self.diags) {
+                Some(ty) => {
+                    span = span.join(ty.span);
+                    ty
+                }
+                None => {
+                    self.recover_in_struct_fields();
+                    self.stream.eat(TokenKind::Comma);
+                    continue;
+                }
+            };
+
+            let default = if let Some(eq_tok) = self.stream.eat(TokenKind::Eq) {
+                match parse_expr(
+                    &mut self.stream,
+                    &mut self.diags,
+                    &mut self.fn_purity,
+                    &mut self.parallel_checks,
+                ) {
+                    Some(expr) => {
+                        span = span.join(expr_span(&expr));
+                        Some(expr)
+                    }
+                    None => {
+                        span = span.join(eq_tok.span);
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            let field = StructField {
+                attrs,
+                name,
+                ty,
+                default,
+                span,
+            };
+            last_span = field.span;
+            fields.push(field);
+
+            if let Some(comma) = self.stream.eat(TokenKind::Comma) {
+                last_span = comma.span;
+            } else if !self.stream.at(TokenKind::RBrace) {
+                let tok = self.stream.peek();
+                self.error(
+                    ParseCode::UnexpectedToken,
+                    tok.span,
+                    "Expected ',' or '}' after struct field",
+                );
+                self.recover_in_struct_fields();
+                self.stream.eat(TokenKind::Comma);
+            }
+        }
+
+        let close_span = if let Some(close) = self.stream.eat(TokenKind::RBrace) {
+            close.span
+        } else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnclosedBrace,
+                tok.span,
+                "Expected '}' to close type body",
+            );
+            last_span
+        };
+
+        let body_span = open.span.join(close_span);
+        Some((fields, body_span))
+    }
+
+    /// Parse a single union alternative inside an `alias` declaration.
+    fn parse_alias_variant(&mut self) -> Option<AliasVariant> {
+        if self.stream.at_keyword(Keyword::Nothing) {
+            let tok = self.stream.bump();
+            return Some(AliasVariant::Nothing { span: tok.span });
+        }
+
+        if self.stream.peek().kind == TokenKind::Ident
+            && self.stream.nth(1).kind == TokenKind::LParen
+        {
+            let (name, name_span) = self.expect_ident("tag name")?;
+            let open = self.stream.bump(); // consume '('
+            let mut args = Vec::new();
+            let mut end_span = open.span;
+
+            if self.stream.at(TokenKind::RParen) {
+                end_span = self.stream.bump().span;
+            } else {
+                loop {
+                    match parse_type_node(&mut self.stream, &mut self.diags) {
+                        Some(arg) => {
+                            end_span = arg.span;
+                            args.push(arg);
+                        }
+                        None => {
+                            self.recover_in_alias_variants();
+                            break;
+                        }
+                    }
+
+                    if self.stream.eat(TokenKind::Comma).is_some() {
+                        continue;
+                    }
+                    break;
+                }
+
+                if let Some(close) = self.stream.eat(TokenKind::RParen) {
+                    end_span = close.span;
+                } else {
+                    let tok = self.stream.peek();
+                    self.error(
+                        ParseCode::UnexpectedToken,
+                        tok.span,
+                        "Expected ')' to close tag variant",
+                    );
+                }
+            }
+
+            let span = name_span.join(end_span);
+            return Some(AliasVariant::Tag { name, args, span });
+        }
+
+        parse_type_node(&mut self.stream, &mut self.diags).map(AliasVariant::Type)
+    }
+
+    /// Recover inside a struct field list by skipping to the next delimiter.
+    fn recover_in_struct_fields(&mut self) {
+        while !self.stream.is_eof() {
+            match self.stream.peek().kind {
+                TokenKind::Comma | TokenKind::RBrace => break,
+                _ => {
+                    self.stream.bump();
+                }
+            }
+        }
+    }
+
+    /// Recover in a generic parameter list until we hit a closing bracket.
+    fn recover_in_generics(&mut self) {
+        while !self.stream.is_eof() {
+            match self.stream.peek().kind {
+                TokenKind::RAngle => {
+                    self.stream.bump();
+                    break;
+                }
+                TokenKind::Comma => break,
+                _ => {
+                    self.stream.bump();
+                }
+            }
+        }
+    }
+
+    /// Recover inside alias variants until the next `|` or `;`.
+    fn recover_in_alias_variants(&mut self) {
+        while !self.stream.is_eof() {
+            match self.stream.peek().kind {
+                TokenKind::Pipe | TokenKind::Semicolon => break,
+                _ => {
+                    self.stream.bump();
+                }
+            }
+        }
     }
 
     fn parse_param_list(&mut self) -> Vec<Param> {

--- a/crates/parser/src/render.rs
+++ b/crates/parser/src/render.rs
@@ -5,8 +5,9 @@ use std::fmt::Write as _;
 use surge_token::{SourceId, Token};
 
 use crate::{
-    AliasDef, Ast, Attr, Block, Expr, ExternBlock, Func, FuncSig, Import, Item, LiteralDef, Module,
-    Param, Pattern, PatternKind, Stmt, StmtOrBlock, TypeDef, TypeNode,
+    AliasDef, AliasVariant, Ast, Attr, Block, Expr, ExternBlock, Func, FuncSig, GenericParam,
+    Import, Item, LiteralDef, Module, NewtypeDef, Param, Pattern, PatternKind, Stmt, StmtOrBlock,
+    StructField, TypeDef, TypeNode,
 };
 
 /// Rendering context passed to AST nodes.
@@ -66,6 +67,11 @@ impl AstRender for Item {
                 ctx.push_str(&format!("{}Fn(\n", indent_str));
                 func.render(ctx, indent + 1);
                 ctx.push_str(&format!("{})", indent_str));
+            }
+            Item::Newtype(newtype_def) => {
+                ctx.push_str(&format!("{}Newtype(\n", indent_str));
+                newtype_def.render(ctx, indent + 1);
+                ctx.push_str(&format!("\n{})", indent_str));
             }
             Item::Let(stmt) => {
                 ctx.push_str(&format!("{}Let(\n", indent_str));
@@ -720,7 +726,112 @@ impl AstRender for TypeDef {
         let indent_str = "  ".repeat(indent);
         ctx.push_str(&format!("{}TypeDef {{\n", indent_str));
         ctx.push_str(&format!("{}  name: \"{}\",\n", indent_str, self.name));
+
+        ctx.push_str(&format!("{}  generics: [", indent_str));
+        for (i, param) in self.generics.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            param.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  attrs: [", indent_str));
+        for (i, attr) in self.attrs.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            attr.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  base: ", indent_str));
+        if let Some(base) = &self.base {
+            base.render(ctx, indent + 1);
+        } else {
+            ctx.push_str("None");
+        }
+        ctx.push_str(",\n");
+
+        ctx.push_str(&format!("{}  fields: [\n", indent_str));
+        for (i, field) in self.fields.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(",\n");
+            }
+            field.render(ctx, indent + 2);
+        }
+        ctx.push_str(&format!("\n{}  ],\n", indent_str));
         ctx.push_str(&format!("{}  span: {:?}\n", indent_str, self.span));
+        ctx.push_str(&format!("{}}}", indent_str));
+    }
+}
+
+impl AstRender for NewtypeDef {
+    fn render(&self, ctx: &mut RenderCtx<'_>, indent: usize) {
+        let indent_str = "  ".repeat(indent);
+        ctx.push_str(&format!("{}NewtypeDef {{\n", indent_str));
+        ctx.push_str(&format!("{}  name: \"{}\",\n", indent_str, self.name));
+
+        ctx.push_str(&format!("{}  generics: [", indent_str));
+        for (i, param) in self.generics.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            param.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  attrs: [", indent_str));
+        for (i, attr) in self.attrs.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            attr.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  ty: ", indent_str));
+        self.ty.render(ctx, indent + 1);
+        ctx.push_str(&format!(",\n{}  span: {:?}\n", indent_str, self.span));
+        ctx.push_str(&format!("{}}}", indent_str));
+    }
+}
+
+impl AstRender for GenericParam {
+    fn render(&self, ctx: &mut RenderCtx<'_>, _indent: usize) {
+        ctx.push_str(&format!(
+            "GenericParam {{ name: \"{}\", span: {:?} }}",
+            self.name, self.span
+        ));
+    }
+}
+
+impl AstRender for StructField {
+    fn render(&self, ctx: &mut RenderCtx<'_>, indent: usize) {
+        let indent_str = "  ".repeat(indent);
+        ctx.push_str(&format!("{}StructField {{\n", indent_str));
+        ctx.push_str(&format!("{}  name: \"{}\",\n", indent_str, self.name));
+
+        ctx.push_str(&format!("{}  attrs: [", indent_str));
+        for (i, attr) in self.attrs.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            attr.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  ty: ", indent_str));
+        self.ty.render(ctx, indent + 1);
+        ctx.push_str(",\n");
+
+        ctx.push_str(&format!("{}  default: ", indent_str));
+        if let Some(default) = &self.default {
+            default.render(ctx, indent + 1);
+        } else {
+            ctx.push_str("None");
+        }
+        ctx.push_str(&format!(",\n{}  span: {:?}\n", indent_str, self.span));
         ctx.push_str(&format!("{}}}", indent_str));
     }
 }
@@ -740,8 +851,61 @@ impl AstRender for AliasDef {
         let indent_str = "  ".repeat(indent);
         ctx.push_str(&format!("{}AliasDef {{\n", indent_str));
         ctx.push_str(&format!("{}  name: \"{}\",\n", indent_str, self.name));
+        ctx.push_str(&format!("{}  generics: [", indent_str));
+        for (i, param) in self.generics.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            param.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  attrs: [", indent_str));
+        for (i, attr) in self.attrs.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            attr.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+
+        ctx.push_str(&format!("{}  variants: [\n", indent_str));
+        for (i, variant) in self.variants.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(",\n");
+            }
+            variant.render(ctx, indent + 2);
+        }
+        ctx.push_str(&format!("\n{}  ],\n", indent_str));
+
         ctx.push_str(&format!("{}  span: {:?}\n", indent_str, self.span));
         ctx.push_str(&format!("{}}}", indent_str));
+    }
+}
+
+impl AstRender for AliasVariant {
+    fn render(&self, ctx: &mut RenderCtx<'_>, indent: usize) {
+        let indent_str = "  ".repeat(indent);
+        match self {
+            AliasVariant::Type(ty) => {
+                ctx.push_str(&format!("{}Type(", indent_str));
+                ty.render(ctx, indent + 1);
+                ctx.push_str(")");
+            }
+            AliasVariant::Nothing { span } => {
+                ctx.push_str(&format!("{}Nothing(span={:?})", indent_str, span));
+            }
+            AliasVariant::Tag { name, args, span } => {
+                ctx.push_str(&format!("{}Tag {{ name: \"{}\", args: [", indent_str, name));
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        ctx.push_str(", ");
+                    }
+                    arg.render(ctx, indent + 1);
+                }
+                ctx.push_str(&format!("], span: {:?} }}", span));
+            }
+        }
     }
 }
 

--- a/crates/parser/src/tests/bad_smoke.rs
+++ b/crates/parser/src/tests/bad_smoke.rs
@@ -202,3 +202,26 @@ fn demo(xs: int[]) -> int {
     let res = parse(src);
     assert_eq!(res.diags[0].code, ParseCode::ParallelBadHeader);
 }
+
+#[test]
+fn reports_type_extension_missing_body() {
+    let src = r#"
+type Derived = Base;
+"#;
+    let res = parse(src);
+    assert_eq!(res.diags[0].code, ParseCode::UnexpectedToken);
+    assert_eq!(
+        res.diags[0].message,
+        "Expected ':' before struct extension body"
+    );
+}
+
+#[test]
+fn reports_alias_missing_semicolon() {
+    let src = r#"
+alias Maybe = int | nothing
+"#;
+    let res = parse(src);
+    assert_eq!(res.diags[0].code, ParseCode::MissingSemicolon);
+    assert_eq!(res.diags[0].message, "Expected ';' after alias definition");
+}

--- a/crates/parser/src/tests/ok_smoke.rs
+++ b/crates/parser/src/tests/ok_smoke.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Attr, BinaryOp, Expr, Item, PatternKind, Stmt};
+use crate::{AliasVariant, Attr, BinaryOp, Expr, Item, PatternKind, Stmt};
 
 #[test]
 fn parses_function_with_return_and_body() {
@@ -179,6 +179,7 @@ fn defaults() -> int {
     total = count + 2;
     return total;
 }
+
 "#;
     let res = parse(src);
     assert_no_parse_errors(&res);
@@ -198,6 +199,98 @@ fn defaults() -> int {
     } else {
         panic!("expected function item");
     }
+}
+
+#[test]
+fn parses_struct_types_with_inheritance_and_defaults() {
+    let src = r#"
+@sealed
+type Person<T> = {
+    name: string,
+    @readonly age: int = 30,
+};
+
+type Employee = Person : {
+    @hidden id: uint64,
+};
+"#;
+    let res = parse(src);
+    assert_no_parse_errors(&res);
+
+    assert_eq!(res.ast.module.items.len(), 2);
+
+    let person = match &res.ast.module.items[0] {
+        Item::Type(def) => def,
+        other => panic!("expected first item to be type, got {other:?}"),
+    };
+    assert_eq!(person.name, "Person");
+    assert_eq!(person.generics.len(), 1);
+    assert_eq!(person.attrs.len(), 1);
+    assert!(matches!(person.attrs[0], Attr::Sealed { .. }));
+    assert!(person.base.is_none());
+    assert_eq!(person.fields.len(), 2);
+    assert!(person.fields[0].attrs.is_empty());
+    assert_eq!(person.fields[0].name, "name");
+    assert!(person.fields[0].default.is_none());
+    assert_eq!(person.fields[1].name, "age");
+    assert!(matches!(
+        person.fields[1].attrs.get(0),
+        Some(Attr::Readonly { .. })
+    ));
+    assert!(person.fields[1].default.is_some());
+
+    let employee = match &res.ast.module.items[1] {
+        Item::Type(def) => def,
+        other => panic!("expected second item to be type, got {other:?}"),
+    };
+    assert!(employee.base.is_some());
+    assert_eq!(employee.fields.len(), 1);
+    assert_eq!(employee.fields[0].name, "id");
+    assert!(matches!(
+        employee.fields[0].attrs.get(0),
+        Some(Attr::Hidden { .. })
+    ));
+}
+
+#[test]
+fn parses_newtypes_and_aliases_with_generics() {
+    let src = r#"
+newtype UserId<T> = uint64;
+alias Maybe<T> = T | nothing;
+alias Option<T> = Some(T) | nothing;
+"#;
+
+    let res = parse(src);
+    assert_no_parse_errors(&res);
+    assert_eq!(res.ast.module.items.len(), 3);
+
+    let newtype = match &res.ast.module.items[0] {
+        Item::Newtype(def) => def,
+        other => panic!("expected newtype, got {other:?}"),
+    };
+    assert_eq!(newtype.name, "UserId");
+    assert_eq!(newtype.generics.len(), 1);
+
+    let alias_maybe = match &res.ast.module.items[1] {
+        Item::Alias(def) => def,
+        other => panic!("expected alias, got {other:?}"),
+    };
+    assert_eq!(alias_maybe.name, "Maybe");
+    assert_eq!(alias_maybe.generics.len(), 1);
+    assert_eq!(alias_maybe.variants.len(), 2);
+
+    let alias_option = match &res.ast.module.items[2] {
+        Item::Alias(def) => def,
+        other => panic!("expected alias, got {other:?}"),
+    };
+    assert_eq!(alias_option.name, "Option");
+    assert_eq!(alias_option.generics.len(), 1);
+    assert_eq!(alias_option.variants.len(), 2);
+    assert!(matches!(alias_option.variants[0], AliasVariant::Tag { .. }));
+    assert!(matches!(
+        alias_option.variants[1],
+        AliasVariant::Nothing { .. }
+    ));
 }
 
 #[test]

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -144,9 +144,11 @@ fn is_type_terminator(kind: TokenKind) -> bool {
             | TokenKind::RParen
             | TokenKind::Semicolon
             | TokenKind::Eq
+            | TokenKind::Colon
             | TokenKind::RBrace
             | TokenKind::LBrace
             | TokenKind::ColonEq
+            | TokenKind::Pipe
             | TokenKind::RAngle
             | TokenKind::Keyword(Keyword::In)
             | TokenKind::Eof


### PR DESCRIPTION
## Summary
- extend the AST to describe struct fields, alias variants, generics, and newtype declarations
- implement parsing for `newtype`, struct `type` (including inheritance and defaults), and `alias` unions with diagnostics and rendering
- update parser tests to cover new type parsing scenarios and adjust type tokenisation rules

## Testing
- `cargo test -p surge-parser`


------
https://chatgpt.com/codex/tasks/task_e_68dd7a9ebf608321a264d7e63dbcfb72