### PR TITLE
Add parser support for user defined type syntax

### DIFF
--- a/crates/diagnostics/src/collect.rs
+++ b/crates/diagnostics/src/collect.rs
@@ -87,6 +87,8 @@ pub fn from_parser_diags(file: SourceId, diags: &[surge_parser::ParseDiag]) -> V
                 }
                 surge_parser::ParseCode::UnexpectedToken => "PARSE_UNEXPECTED_TOKEN".into(),
                 surge_parser::ParseCode::InvalidArraySyntax => "PARSE_INVALID_ARRAY_SYNTAX".into(),
+                surge_parser::ParseCode::FieldConflict => "PARSE_FIELD_CONFLICT".into(),
+                surge_parser::ParseCode::DuplicateLiteral => "PARSE_DUPLICATE_LITERAL".into(),
                 surge_parser::ParseCode::IncompleteFunction => "PARSE_INCOMPLETE_FUNCTION".into(),
                 surge_parser::ParseCode::Recoverable => "PARSE_RECOVERABLE".into(),
             });

--- a/crates/parser/src/ast/nodes.rs
+++ b/crates/parser/src/ast/nodes.rs
@@ -22,6 +22,7 @@ pub enum Item {
     Type(TypeDef),
     Literal(LiteralDef),
     Alias(AliasDef),
+    Tag(TagDef),
     Extern(ExternBlock),
     Import(Import),
     Let(Stmt),
@@ -426,6 +427,25 @@ pub enum AliasVariant {
 #[derive(Debug)]
 pub struct LiteralDef {
     pub name: String,
+    pub values: Vec<LiteralVariant>,
+    pub attrs: Vec<Attr>,
+    pub span: Span,
+}
+
+/// Individual literal alternative as part of a `literal` declaration.
+#[derive(Debug)]
+pub struct LiteralVariant {
+    pub value: String,
+    pub span: Span,
+}
+
+/// Tagged constructor declaration used by tagged unions.
+#[derive(Debug)]
+pub struct TagDef {
+    pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub params: Vec<TypeNode>,
+    pub attrs: Vec<Attr>,
     pub span: Span,
 }
 

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -35,6 +35,8 @@ pub enum ParseCode {
     InvalidArraySyntax,
     IncompleteFunction,
     Recoverable,
+    FieldConflict,
+    DuplicateLiteral,
 }
 
 /// Parser diagnostic with message and related spans.

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -14,8 +14,9 @@ mod types;
 
 pub use ast::{
     AliasDef, AliasVariant, AssignOp, Ast, Attr, BinaryOp, Block, CompareArm, Expr, ExternBlock,
-    Func, FuncSig, GenericParam, Import, Item, LiteralDef, Module, NewtypeDef, Param, Pattern,
-    PatternKind, Stmt, StmtOrBlock, StructField, TypeDef, TypeNode, UnaryOp,
+    Func, FuncSig, GenericParam, Import, Item, LiteralDef, LiteralVariant, Module, NewtypeDef,
+    Param, Pattern, PatternKind, Stmt, StmtOrBlock, StructField, TagDef, TypeDef, TypeNode,
+    UnaryOp,
 };
 pub use error::{ParseCode, ParseDiag};
 pub use parser::{ParseResult, parse_source, parse_source_with_options, parse_tokens};

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -9,7 +9,7 @@ use crate::lexer_api::Stream;
 use crate::statements::{parse_block, parse_stmt};
 use crate::sync::is_top_level_sync;
 use crate::types::parse_type_node;
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 use surge_token::{Keyword, SourceId, Span, Token, TokenKind};
 
 /// Parsing outcome containing AST and diagnostics.
@@ -127,9 +127,17 @@ impl<'src> Parser<'src> {
             return self.parse_alias(attrs).map(Item::Alias);
         }
 
+        if self.stream.at_keyword(Keyword::Literal) {
+            return self.parse_literal(attrs).map(Item::Literal);
+        }
+
+        if self.stream.at_keyword(Keyword::Tag) {
+            return self.parse_tag(attrs).map(Item::Tag);
+        }
+
         if let Some(keyword) = self.stream.peek_keyword() {
             match keyword {
-                Keyword::Literal | Keyword::Import => {
+                Keyword::Import => {
                     let tok = self.stream.bump();
                     self.error(
                         ParseCode::UnexpectedToken,
@@ -541,6 +549,191 @@ impl<'src> Parser<'src> {
         })
     }
 
+    /// Parse a `literal Name = "foo" | "bar";` declaration.
+    fn parse_literal(&mut self, attrs: Vec<Attr>) -> Option<LiteralDef> {
+        let Some(literal_tok) = self.stream.eat_keyword(Keyword::Literal) else {
+            let tok = self.stream.bump();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected 'literal' keyword",
+            );
+            return None;
+        };
+
+        let (name, name_span) = self.expect_ident("literal name")?;
+
+        let Some(eq_tok) = self.stream.eat(TokenKind::Eq) else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected '=' after literal name",
+            );
+            return None;
+        };
+
+        // Track literal alternatives to flag duplicates early (E_FIELD_CONFLICT equivalent for literals).
+        let mut seen = HashMap::<String, Span>::new();
+        let mut values = Vec::new();
+        let mut last_span = eq_tok.span;
+
+        while !self.stream.is_eof() {
+            match self.expect_string_literal("literal alternative") {
+                Some((value, span)) => {
+                    last_span = span;
+                    match seen.entry(value.clone()) {
+                        Entry::Vacant(slot) => {
+                            slot.insert(span);
+                        }
+                        Entry::Occupied(entry) => {
+                            let prev = *entry.get();
+                            let display_value = self
+                                .stream
+                                .slice(span)
+                                .map(|s| s.to_string())
+                                .unwrap_or_else(|| format!("\"{}\"", value));
+                            let diag = ParseDiag::new(
+                                ParseCode::DuplicateLiteral,
+                                span,
+                                format!(
+                                    "Literal value {} is declared multiple times",
+                                    display_value
+                                ),
+                            )
+                            .with_related(prev, "Previous declaration here");
+                            self.diags.push(diag);
+                        }
+                    }
+                    values.push(LiteralVariant { value, span });
+                }
+                None => {
+                    self.recover_in_literal_values();
+                }
+            }
+
+            if self.stream.eat(TokenKind::Pipe).is_some() {
+                continue;
+            }
+            break;
+        }
+
+        if values.is_empty() {
+            self.error(
+                ParseCode::UnexpectedToken,
+                self.stream.peek().span,
+                "Expected at least one literal alternative",
+            );
+        }
+
+        let mut span = literal_tok.span.join(name_span);
+        span = span.join(last_span);
+        if let Some(semi) = self.stream.eat(TokenKind::Semicolon) {
+            span = span.join(semi.span);
+        } else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::MissingSemicolon,
+                tok.span,
+                "Expected ';' after literal definition",
+            );
+        }
+
+        Some(LiteralDef {
+            name,
+            values,
+            attrs,
+            span,
+        })
+    }
+
+    /// Parse a `tag Name<T>(args);` declaration.
+    fn parse_tag(&mut self, attrs: Vec<Attr>) -> Option<TagDef> {
+        let Some(tag_tok) = self.stream.eat_keyword(Keyword::Tag) else {
+            let tok = self.stream.bump();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected 'tag' keyword",
+            );
+            return None;
+        };
+
+        let (name, name_span) = self.expect_ident("tag name")?;
+        let generics = self.parse_generic_params();
+
+        let Some(open) = self.stream.eat(TokenKind::LParen) else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::UnexpectedToken,
+                tok.span,
+                "Expected '(' after tag name",
+            );
+            return None;
+        };
+
+        let mut params = Vec::new();
+        let mut end_span = open.span;
+
+        if self.stream.at(TokenKind::RParen) {
+            end_span = self.stream.bump().span;
+        } else {
+            while !self.stream.is_eof() {
+                match parse_type_node(&mut self.stream, &mut self.diags) {
+                    Some(ty) => {
+                        end_span = ty.span;
+                        params.push(ty);
+                    }
+                    None => {
+                        self.recover_in_tag_params();
+                        break;
+                    }
+                }
+
+                if self.stream.eat(TokenKind::Comma).is_some() {
+                    continue;
+                }
+                break;
+            }
+
+            if let Some(close) = self.stream.eat(TokenKind::RParen) {
+                end_span = close.span;
+            } else {
+                let tok = self.stream.peek();
+                self.error(
+                    ParseCode::UnexpectedToken,
+                    tok.span,
+                    "Expected ')' to close tag parameters",
+                );
+            }
+        }
+
+        let mut span = tag_tok.span.join(name_span);
+        if let Some(last_generic) = generics.last() {
+            span = span.join(last_generic.span);
+        }
+        span = span.join(end_span);
+
+        if let Some(semi) = self.stream.eat(TokenKind::Semicolon) {
+            span = span.join(semi.span);
+        } else {
+            let tok = self.stream.peek();
+            self.error(
+                ParseCode::MissingSemicolon,
+                tok.span,
+                "Expected ';' after tag declaration",
+            );
+        }
+
+        Some(TagDef {
+            name,
+            generics,
+            params,
+            attrs,
+            span,
+        })
+    }
+
     /// Parse `<T, U>` generic parameter lists shared between newtype, alias and type definitions.
     fn parse_generic_params(&mut self) -> Vec<GenericParam> {
         if !self.stream.at(TokenKind::LAngle) {
@@ -616,6 +809,7 @@ impl<'src> Parser<'src> {
 
         let mut fields = Vec::new();
         let mut last_span = open.span;
+        let mut seen_fields = HashMap::<String, Span>::new();
 
         while !self.stream.at(TokenKind::RBrace) && !self.stream.is_eof() {
             let attrs = parse_attrs(&mut self.stream, &mut self.diags);
@@ -693,6 +887,22 @@ impl<'src> Parser<'src> {
                 span,
             };
             last_span = field.span;
+            match seen_fields.entry(field.name.clone()) {
+                Entry::Vacant(slot) => {
+                    slot.insert(field.span);
+                }
+                Entry::Occupied(entry) => {
+                    let prev = *entry.get();
+                    // Emit E_FIELD_CONFLICT eagerly so extensions surface duplicates during parsing.
+                    let diag = ParseDiag::new(
+                        ParseCode::FieldConflict,
+                        field.span,
+                        format!("Field '{}' is declared multiple times", field.name),
+                    )
+                    .with_related(prev, "Previous declaration here");
+                    self.diags.push(diag);
+                }
+            }
             fields.push(field);
 
             if let Some(comma) = self.stream.eat(TokenKind::Comma) {
@@ -820,6 +1030,30 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Skip tokens until the next literal delimiter to keep error recovery predictable.
+    fn recover_in_literal_values(&mut self) {
+        while !self.stream.is_eof() {
+            match self.stream.peek().kind {
+                TokenKind::Pipe | TokenKind::Semicolon => break,
+                _ => {
+                    self.stream.bump();
+                }
+            }
+        }
+    }
+
+    /// Skip to the next comma or closing parenthesis when a tag parameter fails to parse.
+    fn recover_in_tag_params(&mut self) {
+        while !self.stream.is_eof() {
+            match self.stream.peek().kind {
+                TokenKind::Comma | TokenKind::RParen => break,
+                _ => {
+                    self.stream.bump();
+                }
+            }
+        }
+    }
+
     fn parse_param_list(&mut self) -> Vec<Param> {
         let mut params = Vec::new();
         let open = match self.stream.eat(TokenKind::LParen) {
@@ -933,6 +1167,28 @@ impl<'src> Parser<'src> {
                 format!("identifier_{}", taken.span.start)
             };
             return Some((name, taken.span));
+        }
+        self.error(
+            ParseCode::UnexpectedToken,
+            tok.span,
+            format!("Expected {what}"),
+        );
+        None
+    }
+
+    fn expect_string_literal(&mut self, what: &str) -> Option<(String, Span)> {
+        let tok = self.stream.peek();
+        if tok.kind == TokenKind::StringLit {
+            let taken = self.stream.bump();
+            if let Some(slice) = self.stream.slice(taken.span) {
+                let text = slice.to_string();
+                if text.len() >= 2 && text.starts_with('"') && text.ends_with('"') {
+                    let inner = text[1..text.len() - 1].to_string();
+                    return Some((inner, taken.span));
+                }
+                return Some((text, taken.span));
+            }
+            return Some((String::new(), taken.span));
         }
         self.error(
             ParseCode::UnexpectedToken,

--- a/crates/parser/src/render.rs
+++ b/crates/parser/src/render.rs
@@ -6,8 +6,8 @@ use surge_token::{SourceId, Token};
 
 use crate::{
     AliasDef, AliasVariant, Ast, Attr, Block, Expr, ExternBlock, Func, FuncSig, GenericParam,
-    Import, Item, LiteralDef, Module, NewtypeDef, Param, Pattern, PatternKind, Stmt, StmtOrBlock,
-    StructField, TypeDef, TypeNode,
+    Import, Item, LiteralDef, LiteralVariant, Module, NewtypeDef, Param, Pattern, PatternKind,
+    Stmt, StmtOrBlock, StructField, TagDef, TypeDef, TypeNode,
 };
 
 /// Rendering context passed to AST nodes.
@@ -91,6 +91,11 @@ impl AstRender for Item {
             Item::Alias(alias_def) => {
                 ctx.push_str(&format!("{}Alias(\n", indent_str));
                 alias_def.render(ctx, indent + 1);
+                ctx.push_str(&format!("\n{})", indent_str));
+            }
+            Item::Tag(tag_def) => {
+                ctx.push_str(&format!("{}Tag(\n", indent_str));
+                tag_def.render(ctx, indent + 1);
                 ctx.push_str(&format!("\n{})", indent_str));
             }
             Item::Extern(extern_block) => {
@@ -841,8 +846,34 @@ impl AstRender for LiteralDef {
         let indent_str = "  ".repeat(indent);
         ctx.push_str(&format!("{}LiteralDef {{\n", indent_str));
         ctx.push_str(&format!("{}  name: \"{}\",\n", indent_str, self.name));
+        ctx.push_str(&format!("{}  attrs: [", indent_str));
+        for (i, attr) in self.attrs.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            attr.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+        ctx.push_str(&format!("{}  values: [\n", indent_str));
+        for (i, value) in self.values.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(",\n");
+            }
+            value.render(ctx, indent + 2);
+        }
+        ctx.push_str(&format!("\n{}  ],\n", indent_str));
         ctx.push_str(&format!("{}  span: {:?}\n", indent_str, self.span));
         ctx.push_str(&format!("{}}}", indent_str));
+    }
+}
+
+impl AstRender for LiteralVariant {
+    fn render(&self, ctx: &mut RenderCtx<'_>, indent: usize) {
+        let indent_str = "  ".repeat(indent);
+        ctx.push_str(&format!(
+            "{}LiteralVariant {{ value: \"{}\", span: {:?} }}",
+            indent_str, self.value, self.span
+        ));
     }
 }
 
@@ -879,6 +910,39 @@ impl AstRender for AliasDef {
         ctx.push_str(&format!("\n{}  ],\n", indent_str));
 
         ctx.push_str(&format!("{}  span: {:?}\n", indent_str, self.span));
+        ctx.push_str(&format!("{}}}", indent_str));
+    }
+}
+
+impl AstRender for TagDef {
+    fn render(&self, ctx: &mut RenderCtx<'_>, indent: usize) {
+        let indent_str = "  ".repeat(indent);
+        ctx.push_str(&format!("{}TagDef {{\n", indent_str));
+        ctx.push_str(&format!("{}  name: \"{}\",\n", indent_str, self.name));
+        ctx.push_str(&format!("{}  generics: [", indent_str));
+        for (i, param) in self.generics.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            param.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+        ctx.push_str(&format!("{}  attrs: [", indent_str));
+        for (i, attr) in self.attrs.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            attr.render(ctx, indent + 1);
+        }
+        ctx.push_str("],\n");
+        ctx.push_str(&format!("{}  params: [", indent_str));
+        for (i, param) in self.params.iter().enumerate() {
+            if i > 0 {
+                ctx.push_str(", ");
+            }
+            param.render(ctx, indent + 1);
+        }
+        ctx.push_str(&format!("],\n{}  span: {:?}\n", indent_str, self.span));
         ctx.push_str(&format!("{}}}", indent_str));
     }
 }

--- a/crates/parser/src/tests/bad_smoke.rs
+++ b/crates/parser/src/tests/bad_smoke.rs
@@ -204,6 +204,38 @@ fn demo(xs: int[]) -> int {
 }
 
 #[test]
+fn reports_duplicate_fields_in_type_body() {
+    let src = r#"
+type Base = { id: int };
+type Derived = Base : {
+    id: int,
+    id: string
+};
+"#;
+
+    let res = parse(src);
+    assert!(
+        res.diags
+            .iter()
+            .any(|diag| diag.code == ParseCode::FieldConflict)
+    );
+}
+
+#[test]
+fn reports_duplicate_literal_alternatives() {
+    let src = r#"
+literal Color = "red" | "red";
+"#;
+
+    let res = parse(src);
+    assert!(
+        res.diags
+            .iter()
+            .any(|diag| diag.code == ParseCode::DuplicateLiteral)
+    );
+}
+
+#[test]
 fn reports_type_extension_missing_body() {
     let src = r#"
 type Derived = Base;

--- a/crates/parser/src/tests/ok_smoke.rs
+++ b/crates/parser/src/tests/ok_smoke.rs
@@ -294,6 +294,43 @@ alias Option<T> = Some(T) | nothing;
 }
 
 #[test]
+fn parses_literal_and_tag_definitions() {
+    let src = r#"
+literal Color = "red" | "green";
+tag Some<T>(T);
+tag None();
+"#;
+
+    let res = parse(src);
+    assert_no_parse_errors(&res);
+    assert_eq!(res.ast.module.items.len(), 3);
+
+    let literal = match &res.ast.module.items[0] {
+        Item::Literal(def) => def,
+        other => panic!("expected literal def, got {other:?}"),
+    };
+    assert_eq!(literal.name, "Color");
+    assert_eq!(literal.values.len(), 2);
+    assert_eq!(literal.values[0].value, "red");
+    assert_eq!(literal.values[1].value, "green");
+
+    let tag_some = match &res.ast.module.items[1] {
+        Item::Tag(def) => def,
+        other => panic!("expected tag def, got {other:?}"),
+    };
+    assert_eq!(tag_some.name, "Some");
+    assert_eq!(tag_some.generics.len(), 1);
+    assert_eq!(tag_some.params.len(), 1);
+
+    let tag_none = match &res.ast.module.items[2] {
+        Item::Tag(def) => def,
+        other => panic!("expected tag def, got {other:?}"),
+    };
+    assert_eq!(tag_none.name, "None");
+    assert!(tag_none.params.is_empty());
+}
+
+#[test]
 fn for_in_parses_pattern_and_optional_type() {
     let src = r#"
 fn walk(seq: Option<int>) {


### PR DESCRIPTION
## Summary
- extend the AST and renderer with literal alternatives and tagged constructors
- implement parsing for `literal` and `tag` items plus duplicate field/literal diagnostics
- expose new diagnostics through the reporter and add regression tests for the new syntax

## Testing
- cargo test -p surge-parser

------
https://chatgpt.com/codex/tasks/task_e_68de201346ac83219d2f6732de55daa9