### PR TITLE
Handle target directive combinators without source text

### DIFF
--- a/crates/parser/src/directives.rs
+++ b/crates/parser/src/directives.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use crate::ast::{DirectiveAnchor, DirectiveBlock, DirectiveBody, DirectiveCondition, SpanExt};
 use crate::error::{ParseCode, ParseDiag};
 use crate::lexer_api::Stream;
-use surge_token::{DirectiveKind, DirectiveSpec, SourceId, Span, Token, TokenContext, TokenKind};
+use surge_token::{
+    DirectiveKind, DirectiveSpec, Keyword, SourceId, Span, Token, TokenContext, TokenKind,
+};
 
 /// Consume a directive block from the token stream if the next token starts one.
 /// Returns `None` when the upcoming token is not a directive header.
@@ -216,7 +218,7 @@ impl<'a> TargetConditionParser<'a> {
     fn parse_prim(&mut self) -> Option<DirectiveCondition> {
         let token = self.next_token()?;
         match &token.kind {
-            TokenKind::Ident => self.parse_ident_start(token),
+            TokenKind::Ident | TokenKind::Keyword(_) => self.parse_ident_start(token),
             _ => {
                 self.diags.push(ParseDiag::new(
                     ParseCode::DirectiveMalformed,
@@ -230,13 +232,14 @@ impl<'a> TargetConditionParser<'a> {
 
     fn parse_ident_start(&mut self, token: Token) -> Option<DirectiveCondition> {
         let ident = self.token_text(&token);
+        let combinator = DirectiveFunction::classify(&token, &ident);
         if self.peek_kind(TokenKind::LParen) {
             self.bump();
-            match ident.as_str() {
-                "all" => self.parse_list(token.span, ListKind::All),
-                "any" => self.parse_list(token.span, ListKind::Any),
-                "not" => self.parse_not(token.span),
-                _ => {
+            match combinator {
+                Some(DirectiveFunction::All) => self.parse_list(token.span, ListKind::All),
+                Some(DirectiveFunction::Any) => self.parse_list(token.span, ListKind::Any),
+                Some(DirectiveFunction::Not) => self.parse_not(token.span),
+                None => {
                     self.diags.push(ParseDiag::new(
                         ParseCode::DirectiveMalformed,
                         token.span,
@@ -346,11 +349,74 @@ impl<'a> TargetConditionParser<'a> {
     }
 
     fn token_text(&self, token: &Token) -> String {
-        self.stream
-            .slice(token.span)
-            .unwrap_or("")
-            .trim_matches('"')
-            .to_string()
+        match token.kind {
+            TokenKind::StringLit => self
+                .stream
+                .slice(token.span)
+                .map(|text| text.trim_matches('"').to_string())
+                .unwrap_or_else(|| format!("<string@{}>", token.span.start)),
+            TokenKind::Ident => self
+                .stream
+                .slice(token.span)
+                .map(|text| text.to_string())
+                .unwrap_or_else(|| format!("identifier_{}", token.span.start)),
+            TokenKind::Keyword(keyword) => self
+                .stream
+                .slice(token.span)
+                .map(|text| text.to_string())
+                .or_else(|| {
+                    DirectiveFunction::from_keyword(keyword).map(|func| func.as_str().to_string())
+                })
+                .unwrap_or_else(|| format!("keyword_{:?}", keyword).to_lowercase()),
+            _ => self
+                .stream
+                .slice(token.span)
+                .map(|text| text.to_string())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// Built-in target directive combinators (all/any/not).
+#[derive(Clone, Copy)]
+enum DirectiveFunction {
+    All,
+    Any,
+    Not,
+}
+
+impl DirectiveFunction {
+    fn from_keyword(keyword: Keyword) -> Option<Self> {
+        match keyword {
+            Keyword::TargetAll => Some(Self::All),
+            Keyword::TargetAny => Some(Self::Any),
+            Keyword::TargetNot => Some(Self::Not),
+            _ => None,
+        }
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "all" => Some(Self::All),
+            "any" => Some(Self::Any),
+            "not" => Some(Self::Not),
+            _ => None,
+        }
+    }
+
+    fn classify(token: &Token, ident: &str) -> Option<Self> {
+        match token.kind {
+            TokenKind::Keyword(keyword) => Self::from_keyword(keyword),
+            _ => Self::from_name(ident),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            DirectiveFunction::All => "all",
+            DirectiveFunction::Any => "any",
+            DirectiveFunction::Not => "not",
+        }
     }
 }
 

--- a/crates/parser/src/tests/tokens_api.rs
+++ b/crates/parser/src/tests/tokens_api.rs
@@ -278,7 +278,7 @@ fn test_examples_12_directives_diagnostics() {
         enable_directives: true,
     };
 
-    let (parse_res, _) = parse_source_with_options(source_id, src, &opts);
+    let (parse_res, lex_res) = parse_source_with_options(source_id, src, &opts);
     let has_directive_malformed = parse_res
         .diags
         .iter()
@@ -287,6 +287,17 @@ fn test_examples_12_directives_diagnostics() {
         !has_directive_malformed,
         "unexpected directive diagnostics: {:?}",
         parse_res.diags
+    );
+
+    let token_parse = parse_tokens(source_id, &lex_res.tokens);
+    let token_has_malformed = token_parse
+        .diags
+        .iter()
+        .any(|d| matches!(d.code, ParseCode::DirectiveMalformed));
+    assert!(
+        !token_has_malformed,
+        "unexpected directive diagnostics when parsing tokens only: {:?}",
+        token_parse.diags
     );
 }
 

--- a/crates/token/src/keyword.rs
+++ b/crates/token/src/keyword.rs
@@ -47,6 +47,9 @@ pub enum Keyword {
     TestAssert,       // test.assert
     BenchmarkMeasure, // benchmark.measure
     TimeMeasure,      // time.measure
+    TargetAll,        // all(...)
+    TargetAny,        // any(...)
+    TargetNot,        // not(...)
                       // Repeat, RandomInt, RandomFloat - removed
 }
 
@@ -108,6 +111,9 @@ pub fn lookup_directive_keyword(ident: &str) -> Option<Keyword> {
         "test.assert" => TestAssert,
         "benchmark.measure" => BenchmarkMeasure,
         "time.measure" => TimeMeasure,
+        "all" => TargetAll,
+        "any" => TargetAny,
+        "not" => TargetNot,
         _ => return None,
     })
 }


### PR DESCRIPTION
## Summary
- classify the target directive combinators through token keywords so `all`, `any`, and `not` parse without a source string
- improve directive identifier extraction fallbacks and wire in a regression that covers parsing tokens only for examples/syntax/12_directives.sg
- extend the directive keyword table with entries for the target combinators

## Testing
- cargo test -p surge-parser test_examples_12_directives_diagnostics -- --nocapture
- cargo run -p cli -- diag examples/syntax/12_directives.sg --enable-directives --format json

------
https://chatgpt.com/codex/tasks/task_e_68deaeaccddc8321a28af04fe2b84ba1